### PR TITLE
Remove hostname redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ npm test
 ## examples
 
 ```
-alpha.phila.gov/(.*)      301 https://www.phila.gov/$1
 /otis                     301 http://www.phillyotis.com
 /parksandrec/(.*)         301 /departments/philadelphia-parks-recreation/
 /revenue/(.*)             301 /departments/department-of-revenue/$1
@@ -30,7 +29,7 @@ Use status code `301` for a redirect, and `200` for a rewrite.
 Patterns are converted to regexes with the following enhancements:
 
 - Case-insensitive
-- `^[^\/]*` is prepended (unless it already starts with `^`)
+- `^` is prepended (unless it already starts with `^`)
 - `/?$` is appended (unless it already ends with `$`)
 
 ## formatting

--- a/src/index.js
+++ b/src/index.js
@@ -23,16 +23,14 @@ async function lambda (event) {
 
 function handler (rules, event) {
   const request = event.Records[0].cf.request
-  const hostname = request.headers.host[0].value
-  const requestUrl = path.join(hostname, request.uri) // e.g. "www.foo.com/bar"
   log('request', request)
 
   // Apply this function to every rule until a match is found
-  const matchedRule = rules.find((rule) => rule.regex.test(requestUrl))
+  const matchedRule = rules.find((rule) => rule.regex.test(request.uri))
 
   if (matchedRule) {
     const { regex, replacement, statusCode } = matchedRule
-    const newLocation = requestUrl.replace(regex, replacement)
+    const newLocation = request.uri.replace(regex, replacement)
 
     if (statusCode >= 300 && statusCode < 400) {
       const response = createRedirect(newLocation, statusCode)

--- a/src/parser.js
+++ b/src/parser.js
@@ -39,7 +39,7 @@ function isEmptyOrComment (line) {
 function enhancePattern (pattern) {
   let newPattern = ''
   if (!pattern.startsWith('^')) {
-    newPattern += '^[^\/]*'
+    newPattern += '^'
   }
 
   newPattern += pattern

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -117,13 +117,6 @@ describe('other', () => {
     const request = handler(rules, event)
     expect(request.uri).toBe('/testing')
   })
-
-  it('redirects requests of alpha.phila.gov to www.phila.gov', async () => {
-    const rules = parseRules('alpha.phila.gov/(.*) 301 https://www.phila.gov/$1')
-    const event = createEvent({ uri: '/testing', host: 'alpha.phila.gov' })
-    const response = handler(rules, event)
-    expectRedirect(response, 'https://www.phila.gov/testing')
-  })
 })
 
 function expectRedirect (response, expectedUri) {

--- a/tests/parser.spec.js
+++ b/tests/parser.spec.js
@@ -25,10 +25,10 @@ describe('parser', () => {
   })
 
   describe('enhancePattern', () => {
-    test('adds leading ^[^\/]* if absent', () => {
+    test('adds leading ^ if absent', () => {
       const pattern = '/old'
       const newPattern = enhancePattern(pattern)
-      expect(newPattern.startsWith('^[^\/]*/old')).toBeTruthy()
+      expect(newPattern.startsWith('^/old')).toBeTruthy()
     })
 
     test('does not add leading ^ if already present', () => {

--- a/tests/rule-validations.spec.js
+++ b/tests/rule-validations.spec.js
@@ -12,9 +12,10 @@ describe('rule validations', () => {
   for (const rule of rules) {
     const ruleTitle = rule.pattern
     describe(ruleTitle, () => {
-      test('does not include protocol in pattern', () => {
-        expect(rule.pattern.startsWith('http')).toBeFalsy()
+      test('pattern starts with / or ^/', () => {
+        expect(rule.pattern.startsWith('/') || rule.pattern.startsWith('^/')).toBeTruthy()
       })
+
       test('valid regex', () => {
         const enhancedPattern = enhancePattern(rule.pattern)
         expect(() => new RegExp(enhancedPattern)).not.toThrow()


### PR DESCRIPTION
Closes #15 since we're handling alpha & beta redirects to www in a [separate lambda function](https://github.com/CityOfPhiladelphia/hostname-redirector).