### PR TITLE
Log whether rules are already loaded on each request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,12 @@ module.exports = {
 
 async function lambda (event) {
   if (!rules) {
+    log('loading rules')
     const rulesFilePath = path.join(__dirname, RULES_FILE)
     const rulesFileContents = fs.readFileSync(rulesFilePath, 'utf8')
     rules = parseRules(rulesFileContents)
+  } else {
+    log('rules already loaded')
   }
   return handler(rules, event)
 }


### PR DESCRIPTION
This serves as a likely proxy of whether ot not it is a cold start. Technically it's not a guarantee: if the `rules.txt` file were invalid or something, it would try to load the rules next request too. So the logs just state that it's loading the rules or that they're already loaded.

FYI @awm33