### PR TITLE
Don't log undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,5 +93,6 @@ function rewriteRequest (request, newLocation) {
 function log (label, data) {
   if (process.env.NODE_ENV === 'test') return
   // use util.inspect so objects aren't collapsed
-  console.log(label, util.inspect(data, false, 10))
+  if (data) console.log(label, util.inspect(data, false, 10))
+  else console.log(label)
 }


### PR DESCRIPTION
Prior to this, the new logs from #29 were logging `loading rules undefined` and `rules already loaded undefined`.

One gotcha here is if somehow a legitimate log is passing an undefined variable to this arg, it won't log `undefined`, which may make debugging challenging. Hope that doesn't cause some future dev to curse me years from now. But it probably is unlikely.