### PR TITLE
Remove trailing $ from realestate tax

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -265,7 +265,7 @@
 /revenue/businesses/taxes/pages/birt.aspx 301  /services/payments-assistance-taxes/business-taxes/business-income-receipts-tax-birt/
 /revenue/businesses/taxes/Pages/hoteltax.aspx 301 /services/payments-assistance-taxes/business-taxes/hotel-tax/
 /revenue/eitc                             301  /documents/earned-income-tax-credit-eitc-employer-notice/
-/revenue/realestatetax$                   301  /revenue/realestatetax/
+/revenue/realestatetax                    301  /revenue/realestatetax/ # also handles case variations in cloudfront behavior
 # /revenue/realestatetax/(.*)             200  http://legacy.phila.gov/revenue/realestatetax/$1 # handled by cloudfront behavior
 /revenue/taxpro/pages/refundpetitions.aspx 301 /documents/income-based-wage-tax-refund-petition/
 /rise/employer/pages/banthebox.aspx       301  /humanrelations/pages/default.aspx


### PR DESCRIPTION
This way it will catch the case variations in realestatetax requests that the cloudfront behavior misses

FYI @akennel