### PR TITLE
Revert "Remove trailing $ from other .NET apps"

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -5,7 +5,7 @@
 /actionguides                             301  /the-latest/#action-guides
 /agefriendly                              301  https://secure.jotform.us/philagov/mca-survey/
 /aqi-redirect                             301  /aqi/
-/aqi                                      301  /aqi/ # also handles case variations in cloudfront behavior
+/aqi$                                     301  /aqi/
 # /aqi/(.*)                               200  http://legacy.phila.gov/aqi/$1 # handled by cloudfront behavior
 /artincityhall                            301  http://creativephl.org/tagged/Exhibitions-and-Performances/
 /arts                                     301  http://creativephl.org/
@@ -216,7 +216,7 @@
 /phillydelivers                           301  /departments/mayor/help-make-sure-phillydelivers-for-amazon/
 /phillystat                               301  /mdo/phillystat
 /phlimmigrantbiz                          301  /posts/office-of-immigrant-affairs/2017-03-09-immigrant-business-week-2017-march-27-april-1/
-/phonedir                                 301  /phonedir/ # also handles case variations in cloudfront behavior
+/phonedir$                                301  /phonedir/
 # /phonedir/(.*)                          200  http://legacy.phila.gov/phonedir/$1 # handled by cloudfront behavior
 /police                                   301  http://www.phillypolice.com/
 /policeovertime                           301  https://phl.secure.force.com/ROWS/
@@ -233,7 +233,7 @@
 /ppr                                      301  /departments/philadelphia-parks-recreation/
 /pra                                      301  http://www.philadelphiaredevelopmentauthority.org
 /press-releases                           301  /the-latest/archives/?template=press_release
-/prisons/inmatelocator                    301  /prisons/inmatelocator/ # also handles case variations in cloudfront behavior
+/prisons/inmatelocator$                   301  /prisons/inmatelocator/
 # /prisons/inmatelocator/(.*)             200  http://legacy.phila.gov/prisons/inmatelocator/$1 # handled by cloudfront behavior
 /privacy/index.html                       301  /Pages/privacy.aspx
 /programs-initiatives                     301  /programs


### PR DESCRIPTION
Reverts CityOfPhiladelphia/phila.gov-router#32 because it didn't actually catch other routes - doh!