### PR TITLE
Remove imggen, pwdwebapi, and asm routes

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -116,7 +116,6 @@
 /homelessservices                         301  http://www.philadelphiaofficeofhomelessservices.org/
 /homestead                                301  /services/property-lots-housing/get-the-homestead-exemption/
 /ima/                                     301  /departments/office-of-immigrant-affairs/
-# /imggen/(.*)                            200  http://legacy.phila.gov/imggen/$1 # handled by cloudfront behavior
 /immigrantheritagemonth                   301  /spotlight/immigrant-heritage-month/
 /income-based-assistance-programs         301  /services/income-based-assistance-programs/income-based-water-bill-assistance/
 /income-based-assistance-programs/longtime-owner-occupants-program-loop 301 /services/income-based-assistance-programs/longtime-owner-occupants-program/
@@ -303,8 +302,6 @@
 /trashday/(.*)                            200  https://cityofphiladelphia.github.io/trashday/$1
 /trb/pages/default.aspx                   301  /departments/tax-review-board/
 /tree-trench                              301  http://www.stormwaterpa.org/keeping-water-on-site-waterview-recreation-center.html?key=0
-# /TSbd/(.*)                              200  http://legacy.phila.gov/$1 # handled by cloudfront behavior
-# /TSPD/(.*)                              200  http://legacy.phila.gov/$1 # handled by cloudfront behavior
 /unitycup                                 301  http://unitycup.phila.gov
 /vacancymap                               301  http://phl.maps.arcgis.com/apps/webappviewer/index.html?id=64ac160773d04952bc17ad895cc00680
 /vendorpayments/?$                        301  https://secure.phila.gov/finance/vendorpayments/
@@ -327,7 +324,6 @@
 /water/iwu.html                           301  /water/wu/wastewater/pages/industrialwaste.aspx
 /water/lead                               301  /water/wu/drinkingwater/lead/Pages/default.aspx
 /water/notifications                      301  /water/aboutus/pages/notifications.aspx
-# /water/pwdwebapi/(.*)                   200  http://legacy.phila.gov/water/pwdwebapi/$1 # handled by cloudfront behavior
 /water/rateboard                          301  /departments/water-sewer-storm-water-rate-board/
 /water/rates                              301  /water/wu/ratesregulationsresp/pages/rates.aspx
 /water/regulations                        301  /water/wu/ratesregulationsresp/pages/regulations.aspx


### PR DESCRIPTION
Tom Swanson said it was all right to shut off imggen and pwdwebapi due to lack of activity.
ASM routes (tspd/tsbd) are no longer necessary because bot detection has been turned off on the F5.

See related [phila.gov-terraform commit](https://github.com/CityOfPhiladelphia/phila.gov-terraform/commit/5e982191e80f8ad174ce1b12243f36e5abf6b8a9).

@akennel please review and merge if this looks right