### PR TITLE
Deploy via s3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ format the file to be more readable.
 Deployment should happen automatically by the [Travis CI configuration](.travis.yml), assuming `claudia.json` is correct and Travis CI has the authentication and cloudfront ID environment varibles set. You can also manually deploy:
 
 - Verify the information in `claudia.json` is correct
-- [Create an `.aws/credentials` file](https://claudiajs.com/tutorials/installing.html#configuring-access-credentials)
+- [Create an `.aws/credentials` file](https://claudiajs.com/tutorials/installing.html#configuring-access-credentials) or set AWS credentials through environment variables
+- Set environment variables `AWS_ROUTER_CODE_BUCKET` and `AWS_CLOUDFRONT_ID`
 - Run the following command, filling in the CloudFront Distribution ID as an environment variable
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "deploy": "npm-run-all --sequential deploy:lambda deploy:cloudfront",
-    "deploy:lambda": "claudia update --version claudia",
+    "deploy:lambda": "claudia update --version claudia --use-s3-bucket $AWS_ROUTER_CODE_BUCKET",
     "deploy:cloudfront": "claudia set-cloudfront-trigger --distribution-id $AWS_CLOUDFRONT_ID --event-types origin-request --version claudia"
   },
   "repository": {


### PR DESCRIPTION
In order for terraform to _create_ the router lambda function, it needs to upload code to it. As far as I know terraform can't fetch the code from this github repo, but it can point to an S3 bucket. So this pull request tells claudia to update the lambda via an s3 bucket, which will keep the s3 bucket up-to-date with the latest code. Note that the S3 bucket is created manually and will be referenced by terraform (assuming this works as we expect).

FYI @jamesmbentley 