### PR TITLE
Use a bash script to deploy & add a staging deployment to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ node_js:
 script:
   - npm test
 deploy:
-  provider: script
-  script: npm run deploy
-  skip_cleanup: true
-  on:
-    branch: master
+  - provider: script
+    script: deploy.sh $PROD_LAMBDA_NAME $PROD_LAMBDA_ROLE $PROD_S3_BUCKET $PROD_CLOUDFRONT_DISTRIBUTION_ID
+    skip_cleanup: true
+    on:
+      branch: master
+
+  - provider: script
+    script: deploy.sh $STAGING_LAMBDA_NAME $STAGING_LAMBDA_ROLE $STAGING_S3_BUCKET $STAGING_CLOUDFRONT_DISTRIBUTION_ID
+    skip_cleanup: true
+    on:
+      branch: staging

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ You can use [tsv-pretty](https://ebay.github.io/tsv-utils-dlang/#tsv-pretty) to
 format the file to be more readable.
 
 ## deployment
-Deployment should happen automatically by the [Travis CI configuration](.travis.yml), assuming `claudia.json` is correct and Travis CI has the authentication and cloudfront ID environment varibles set. You can also manually deploy:
+Deployment will happen automatically via [Travis CI](https://travis-ci.org/CityOfPhiladelphia/phila.gov-router) based on [.travis.yml](.travis.yml):
 
-- Verify the information in `claudia.json` is correct
-- [Create an `.aws/credentials` file](https://claudiajs.com/tutorials/installing.html#configuring-access-credentials) or set AWS credentials through environment variables
-- Set environment variables `AWS_ROUTER_CODE_BUCKET` and `AWS_CLOUDFRONT_ID`
-- Run the following command, filling in the CloudFront Distribution ID as an environment variable
+- Pushes to the `staging` branch will deploy to the **staging** environment.
+- Pushes to the `master` branch will deploy to the **production** environment.
 
-```bash
-AWS_CLOUDFRONT_ID=xxxxxx npm run deploy
+You can skip deployment on a push by specifying `[no ci]` in the commit message.
+
+Once you've run `npm install` locally, you can deploy the router manually using the [deploy script](deploy.sh):
+
+```sh
+$ ./deploy.sh $LAMBDA_NAME $LAMBDA_ROLE $S3_BUCKET $CLOUDFRONT_DISTRIBUTION_ID
 ```

--- a/clauda.json
+++ b/clauda.json
@@ -1,0 +1,7 @@
+{
+  "lambda": {
+    "role": "test-phila-gov-router20180521213148950500000001",
+    "name": "test-phila-gov-router",
+    "region": "us-east-1"
+  }
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# We need to deploy the lambda function, then update the
+# cloudfront trigger to use the new lambda version. Claudia
+# lets us do this with two commands if we have a JSON file
+# in place, but we also have to pass a couple args via CLI.
+# This deploy script is just a wrapper around those two commands
+# so it can be called purely using CLI args. That way the travis
+# config can pass it the appropriate environment variables and
+# the way deployment works should hopefully be more explicit.
+
+LAMBDA_NAME=$1
+LAMBDA_ROLE=$2
+S3_BUCKET=$3
+CLOUDFRONT_DISTRIBUTION_ID=$4
+
+if [ "$#" -ne 4 ]; then
+  echo "Command requires 4 args: LAMBDA_NAME, LAMBDA_ROLE, S3_BUCKET, CLOUDFRONT_DISTRIBUTION_ID" >&2
+  exit
+fi
+
+# Create clauda.json file using env vars
+rm -f claudia.json
+cat << EOF > claudia.json
+{
+  "lambda": {
+    "role": "$LAMBDA_ROLE",
+    "name": "$LAMBDA_NAME",
+    "region": "us-east-1"
+  }
+}
+EOF
+
+echo "Deploying $LAMBDA_NAME to $CLOUDFRONT_DISTRIBUTION_ID"
+
+# npx uses the local dependency if it's installed;
+# otherwise it pulls the latest version from npm
+npx claudia update \
+  --version claudia \
+  --use-s3-bucket $S3_BUCKET \
+&& npx claudia set-cloudfront-trigger \
+  --distribution-id $CLOUDFRONT_DISTRIBUTION_ID \
+  --event-types origin-request \
+  --version claudia

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,7 +16,7 @@ CLOUDFRONT_DISTRIBUTION_ID=$4
 
 if [ "$#" -ne 4 ]; then
   echo "Command requires 4 args: LAMBDA_NAME, LAMBDA_ROLE, S3_BUCKET, CLOUDFRONT_DISTRIBUTION_ID" >&2
-  exit
+  exit 1
 fi
 
 # Create clauda.json file using env vars

--- a/package-lock.json
+++ b/package-lock.json
@@ -465,24 +465,6 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
-    },
-    "array-map": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
-    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
@@ -1507,12 +1489,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
-    },
     "duplexify": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
@@ -1643,21 +1619,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
-    },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
     },
     "events": {
       "version": "1.1.1",
@@ -1880,12 +1841,6 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -3593,12 +3548,6 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3781,12 +3730,6 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3810,12 +3753,6 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
-    },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-      "dev": true
     },
     "merge": {
       "version": "1.2.0",
@@ -3984,12 +3921,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
-      "dev": true
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4027,92 +3958,6 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
-      }
-    },
-    "npm-run-all": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
-      "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.4",
-        "memorystream": "^0.3.1",
-        "minimatch": "^3.0.4",
-        "ps-tree": "^1.1.0",
-        "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
-        "string.prototype.padend": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
       }
     },
     "npm-run-path": {
@@ -4404,15 +4249,6 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "~2.3"
-      }
-    },
     "peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -4513,15 +4349,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
-    },
-    "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true,
-      "requires": {
-        "event-stream": "~3.3.0"
-      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -5205,18 +5032,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shell-quote": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
-      "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
-    },
     "shelljs": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
@@ -5424,15 +5239,6 @@
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5497,15 +5303,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1"
-      }
-    },
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
@@ -5530,17 +5327,6 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
-      }
-    },
-    "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -5931,12 +5717,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-      "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Lambda@Edge function for handling redirects and rewrites",
   "main": "src/index.js",
   "scripts": {
-    "test": "jest",
-    "deploy": "npm-run-all --sequential deploy:lambda deploy:cloudfront",
-    "deploy:lambda": "claudia update --version claudia --use-s3-bucket $AWS_ROUTER_CODE_BUCKET",
-    "deploy:cloudfront": "claudia set-cloudfront-trigger --distribution-id $AWS_CLOUDFRONT_ID --event-types origin-request --version claudia"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -18,7 +15,6 @@
   "devDependencies": {
     "claudia": "^5.0.0",
     "jest": "^22.4.4",
-    "npm-run-all": "^4.1.3",
     "safe-regex": "^1.1.0"
   }
 }


### PR DESCRIPTION
I was trying to avoid writing a bash script to do the deploy as I thought it would make it overly complex, but frankly I think the way it was, with some configs in the `claudia.json` and others in the travis dashboard as env vars, was even more confusing. This pull request stores all config as travis variables, and passes them explicitly (in the `.travis.yml`) to `deploy.sh`, which takes care of the rest on the travis server.

Any thoughts before I merge, @akennel?