### PR TITLE
Add rules for dropdown menu headers redirecting to child page

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -56,6 +56,19 @@
 /departments/(.*)/all-events              301  /the-latest/all-events/
 /departments/board-of-education           301  /departments/philadelphia-board-of-education/
 /departments/commission-on-parks-and-recreation 301 /departments/philadelphia-parks-recreation/about/the-commission-on-parks-recreation/
+
+# clicking the dropdown menu header should take you to one of its pages
+/departments/department-of-revenue/about            301  /departments/department-of-revenue/about/contact-us/ # first page of dropdown menu
+/departments/department-of-revenue/our-services/    301 /departments/department-of-revenue/our-services/tax-services/ # first page of dropdown menu
+/departments/department-of-revenue/programs/        301 /departments/department-of-revenue/programs/for-businesses/ # first page of dropdown menu
+/departments/department-of-human-services/about-us/ 301 /departments/department-of-human-services/about-us/key-partnerships/
+/departments/mayors-office-of-education/about/      301 /departments/mayors-office-of-education/about/what-we-do/
+/departments/office-of-open-data-and-digital-transformation/about/          301 /departments/office-of-open-data-and-digital-transformation/about/staff/ # first page of dropdown menu
+/departments/office-of-open-data-and-digital-transformation/speaker-series/ 301 /departments/office-of-open-data-and-digital-transformation/speaker-series/overview/ # first page of dropdown menu
+/departments/office-of-sustainability/about/        301 /departments/office-of-sustainability/about/what-we-do/ # first page of dropdown menu
+/departments/office-of-sustainability/programs/     301 /departments/office-of-sustainability/programs/climate-adaptation-planning/
+/departments/office-of-sustainability/greenworks/   301 /departments/office-of-sustainability/greenworks/greenworks-review/
+
 /departments/education                    301  /departments/mayors-office-of-education/
 /departments/emergency-management         301  /departments/oem
 /departments/emergency-management/(.*)    301  /departments/oem/$1


### PR DESCRIPTION
We may not need this if @karissademi creates auto-generated pages for the menu headers instead. But at least this is ready to go in case we need it. If we create the index pages before launch, just revert this PR.