### PR TITLE
Match all routes under /philacode

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -226,7 +226,7 @@
 /paymentplans                             301  /services/payments-assistance-taxes/payment-plans/set-up-a-payment-agreement-for-your-taxes/
 /pchr                                     301  /humanrelations
 /performance                              301  /mdo/phillystat
-/philacode                                301  http://www.amlegal.com/codes/client/philadelphia_pa/
+/philacode/?.*                            301  http://www.amlegal.com/codes/client/philadelphia_pa/
 /phillydelivers                           301  /departments/mayor/help-make-sure-phillydelivers-for-amazon/
 /phillystat                               301  /mdo/phillystat
 /phlimmigrantbiz                          301  /posts/office-of-immigrant-affairs/2017-03-09-immigrant-business-week-2017-march-27-april-1/


### PR DESCRIPTION
A service page has a link to `http://www.phila.gov/philacode/html/_data/title19/CHAPTER_19_500_TAXES_AND_RENTS/19_509_Interest_Penalties_and_.html` that was 404ing.