### PR TITLE
Remove internal hostname from /eeocomplaint rule

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -370,5 +370,4 @@
 /senior-freeze                            301  /services/payments-assistance-taxes/senior-citizen-discounts/low-income-senior-citizen-real-estate-tax-freeze/
 /clip/vacantlotprogram/pages/default.aspx 301  /programs/vacant-lot-program/
 /active-duty-credit                       301  /services/payments-assistance-taxes/tax-credits/active-duty-tax-credit/
-/eeocomplaint?                            301  https://beta.phila.gov/services/working-jobs/file-a-sexual-harassment-complaint/
-/eeo-complaint                            301  https://beta.phila.gov/services/working-jobs/file-a-sexual-harassment-complaint/
+/eeo-?complaint?                          301  /services/working-jobs/file-a-sexual-harassment-complaint/


### PR DESCRIPTION
@akennel you can leave off the hostname when it's an internal redirect. I also consolidated these rules into a single one but that doesn't make much of a difference.

These rules will still work when we go live, but people will get two 301 redirects: one from what they typed in to beta, and one from beta to www. Please feel free to merge and deploy this when you're back.