### PR TITLE
Add redirect for /wp-admin and /wp-login.php

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -332,6 +332,8 @@
 /welcomingweek2017                        301  /posts/office-of-immigrant-affairs/2017-08-31-welcoming-week-2017/
 /wills                                    301  http://secureprod.phila.gov/wills/
 /workforce                                301  /programs/workforce-development/
+/wp-admin                                 301  https://admin.phila.gov/wp-admin/
+/wp-login.php                             301  https://admin.phila.gov/wp-login.php
 /youthcommission/pages/default.aspx       301  /youthengagement/pages/default.aspx
 /zika                                     301  /health/diseasecontrol/zika.html
 /zoningarchive                            301  /services/zoning-planning-development/look-up-zoning-information/


### PR DESCRIPTION
Note that this will not pass along the `?redirect_to` querystring. Also note that this will work the same on staging and prod (it won't ever redirect you to the staging admin site).