### PR TITLE
Add redirects for external program pages

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -358,3 +358,5 @@
 /active-duty-credit                       301  /services/payments-assistance-taxes/tax-credits/active-duty-tax-credit/
 /eeo-?complaint?                          301  /services/working-jobs/file-a-sexual-harassment-complaint/
 /solarmap                                 301  https://phl.maps.arcgis.com/apps/MapSeries/index.html?appid=c1a5d30acec04aec8c4acfa4cc60a311
+/programs/rebuild                         301  http://rebuild.phila.gov/
+/programs/startup-phl/                    301  http://startupphl.com/


### PR DESCRIPTION
`https` is not currently supported on these subdomains.