### PR TITLE
Content under /realestate should not be redirected to the Commerce homepage

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -361,12 +361,13 @@
 /solarmap                                 301  https://phl.maps.arcgis.com/apps/MapSeries/index.html?appid=c1a5d30acec04aec8c4acfa4cc60a311
 /programs/rebuild                         301  http://rebuild.phila.gov/
 /programs/startup-phl/                    301  http://startupphl.com/
-/welcoming-week                             301  /spotlight/welcoming-week-2018/
+/welcoming-week                           301  /spotlight/welcoming-week-2018/
 /commerce/doBusiness/Pages/default.aspx   301  /services/business-self-employment/do-business-with-the-city/
 /commerce/businesssupport/mwdsbesupport/pages/default.aspx 301 /departments/office-of-economic-opportunity/
 /commerce/businessAttraction/Pages/default.aspx 301 /departments/department-of-commerce/about-us/divisions/office-of-business-development/
 /commerce/neighborhoods/Pages/default.aspx 301 /departments/department-of-commerce/investing-in-neighborhoods/
 /commerce/businessSupport/Pages/default.aspx 301 /departments/department-of-commerce/supporting-business/
+/commerce/realestate/?(.*)                301  /commerce/realestate/$1
 /commerce/(.*)                            301  /departments/department-of-commerce/
 /businesssupport                          301  /departments/department-of-commerce/supporting-business/
 /businessattraction                       301  /departments/department-of-commerce/about-us/divisions/office-of-business-development/


### PR DESCRIPTION
This content will eventually be moved to WordPress, but the migration process has not been completed yet.