### PR TITLE
Redirect /aging and all it's children

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -5,6 +5,7 @@
 /aco                                      301  /mcpd/
 /actionguides                             301  /the-latest/#action-guides
 /agefriendly                              301  https://secure.jotform.us/philagov/mca-survey/
+/aging(.*)                                301  /departments/mayors-commission-on-aging/
 /aqi-redirect                             301  /aqi/
 /aqi$                                     301  /aqi/
 # /aqi/(.*)                               200  http://legacy.phila.gov/aqi/$1 # handled by cloudfront behavior


### PR DESCRIPTION
WordPress presence replaces SharePoint.